### PR TITLE
fix: remove gradient background from camera emoji in title

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import {
 // Create the UI
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div class="container">
-    <h1>Camera Access App 📸</h1>
+    <h1><span class="gradient-text">Camera Access App</span> 📸</h1>
     <p class="subtitle">Test camera and biometric authentication</p>
 
     <div class="video-container">

--- a/src/style.css
+++ b/src/style.css
@@ -46,6 +46,9 @@ h1 {
   font-size: 2.5rem;
   font-weight: 700;
   margin: 0;
+}
+
+h1 .gradient-text {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -228,7 +231,7 @@ video.active ~ .video-container::before {
     background-color: #f5f5f5;
   }
 
-  h1 {
+  h1 .gradient-text {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;


### PR DESCRIPTION
Fixes #4

The camera emoji was getting affected by the h1 gradient background, making it appear with a gradient overlay instead of its natural appearance. Wrapped the text portion in a span with gradient-text class so the gradient only applies to the text, leaving the emoji as clear text.

### Changes
- Wrapped text in `<span class="gradient-text">` element
- Moved gradient CSS from `h1` to `h1 .gradient-text`
- Emoji now displays naturally without gradient effect

Generated with [Claude Code](https://claude.ai/code)